### PR TITLE
Prefix support, improved tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Basic logger defaulting to `npmlog` with special consideration for running
 tests (doesn't output logs when run with `_TESTING=1` in the env).
 
 ```js
-import { default as log } from 'appium-logger';
-
+import { getLogger } from 'appium-logger';
+let log = getLogger('mymodule');
 log.info("hi!");
 ```

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,16 +1,39 @@
 import npmlog from 'npmlog';
 
-const npmLevels = ['silly', 'verbose', 'info', 'http', 'warn', 'error'];
+const npmLevels = ['silly', 'verbose', 'debug', 'info', 'http', 'warn', 'error'];
 let mockLog = {};
 for (let l of npmLevels) {
   mockLog[l] = () => {};
 }
 
-export function getLogger () {
+export function patchLogger(logger) {
+  if (!logger.debug) {
+    logger.addLevel('debug', 1000, { fg: 'blue', bg: 'black' }, 'dbg');
+  }
+}
+
+function _getLogger () {
   const testingMode = parseInt(process.env._TESTING, 10) === 1;
   const forceLogMode = parseInt(process.env._FORCE_LOGS, 10) === 1;
-  return (testingMode && !forceLogMode) ? mockLog :
-                                          (global._global_npmlog || npmlog);
+  let logger = (testingMode && !forceLogMode) ? mockLog :
+    (global._global_npmlog || npmlog);
+  patchLogger(logger);
+  return logger;
+}
+
+export function getLogger(prefix=null) {
+  let logger = _getLogger();
+  let wrappedLogger = {};
+  Object.defineProperty(wrappedLogger, 'level', {
+    get: function() { return logger.level; },
+    set: function(newValue) { logger.level = newValue; },
+    enumerable: true,
+    configurable: true
+  });
+  for(let k of npmLevels) {
+    wrappedLogger[k] = logger[k].bind(logger, prefix);
+  }
+  return wrappedLogger;
 }
 
 const log = getLogger();

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,12 +21,12 @@ function _getLogger () {
   return logger;
 }
 
-export function getLogger(prefix=null) {
+export function getLogger(prefix = null) {
   let logger = _getLogger();
   let wrappedLogger = {};
   Object.defineProperty(wrappedLogger, 'level', {
-    get: function() { return logger.level; },
-    set: function(newValue) { logger.level = newValue; },
+    get: function () { return logger.level; },
+    set: function (newValue) { logger.level = newValue; },
     enumerable: true,
     configurable: true
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,10 +9,10 @@ function setupWriters () {
           'stderr': sinon.spy(process.stderr, 'write')};
 }
 
-function getDynamicLogger (testingMode, forceLogs) {
+function getDynamicLogger (testingMode, forceLogs, prefix=null) {
   process.env._TESTING = testingMode ? '1' : '0';
   process.env._FORCE_LOGS = forceLogs ? '1' : '0';
-  return getLogger();
+  return getLogger(prefix);
 }
 
 function restoreWriters (writers) {
@@ -23,9 +23,13 @@ function restoreWriters (writers) {
 
 function assertOutputContains (writers, output) {
   let someoneHadOutput = false;
+  let matchOutput = sinon.match(function (value) {
+    return value && value.indexOf(output) >= 0;
+  }, "matchOutput");
+
   for (let w of _.values(writers)) {
     if (w.calledWith) {
-      someoneHadOutput = w.calledWith(output);
+      someoneHadOutput = w.calledWithMatch(matchOutput);
       if (someoneHadOutput) break;
     }
   }

--- a/test/logger-force-specs.js
+++ b/test/logger-force-specs.js
@@ -20,14 +20,15 @@ describe('logger with force log', () => {
     assertOutputContains(writers, 'silly');
     log.verbose('verbose');
     assertOutputContains(writers, 'verbose');
+    log.verbose('debug');
+    assertOutputContains(writers, 'debug');
     log.info('info');
     assertOutputContains(writers, 'info');
     log.http('http');
     assertOutputContains(writers, 'http');
     log.warn('warn');
     assertOutputContains(writers, 'warn');
-    log.error(null, 'error');
-    // npmlog adds a space before and a newline after error messages
-    assertOutputContains(writers, ' error\n');
+    log.error('error');
+    assertOutputContains(writers, 'error');
   });
 });

--- a/test/logger-normal-specs.js
+++ b/test/logger-normal-specs.js
@@ -3,7 +3,7 @@
 import { getDynamicLogger, restoreWriters, setupWriters,
          assertOutputContains } from './helpers';
 
-describe('logger', () => {
+describe('normal logger', () => {
   let writers, log;
   before(() => {
     writers = setupWriters();
@@ -20,14 +20,52 @@ describe('logger', () => {
     assertOutputContains(writers, 'silly');
     log.verbose('verbose');
     assertOutputContains(writers, 'verbose');
+    log.verbose('debug');
+    assertOutputContains(writers, 'debug');
     log.info('info');
     assertOutputContains(writers, 'info');
     log.http('http');
     assertOutputContains(writers, 'http');
     log.warn('warn');
     assertOutputContains(writers, 'warn');
-    log.error(null, 'error');
-    // npmlog adds a space before and a newline after error messages
-    assertOutputContains(writers, ' error\n');
+    log.error('error');
+    assertOutputContains(writers, 'error');
+  });
+});
+
+describe('normal logger with prefix', () => {
+  let writers, log;
+  before(() => {
+    writers = setupWriters();
+    log = getDynamicLogger(false, false, 'myprefix');
+    log.level = 'silly';
+  });
+
+  after(() => {
+    restoreWriters(writers);
+  });
+
+  it('should not rewrite log levels outside of testing', () => {
+    log.silly('silly');
+    assertOutputContains(writers, 'silly');
+    assertOutputContains(writers, 'myprefix');
+    log.verbose('verbose');
+    assertOutputContains(writers, 'verbose');
+    assertOutputContains(writers, 'myprefix');
+    log.verbose('debug');
+    assertOutputContains(writers, 'debug');
+    assertOutputContains(writers, 'myprefix');
+    log.info('info');
+    assertOutputContains(writers, 'info');
+    assertOutputContains(writers, 'myprefix');
+    log.http('http');
+    assertOutputContains(writers, 'http');
+    assertOutputContains(writers, 'myprefix');
+    log.warn('warn');
+    assertOutputContains(writers, 'warn');
+    assertOutputContains(writers, 'myprefix');
+    log.error('error');
+    assertOutputContains(writers, 'error');
+    assertOutputContains(writers, 'myprefix');
   });
 });

--- a/test/logger-test-specs.js
+++ b/test/logger-test-specs.js
@@ -3,7 +3,7 @@
 import { getDynamicLogger, restoreWriters, setupWriters,
          assertOutputDoesntContain } from './helpers';
 
-describe('logger', () => {
+describe('test logger', () => {
   let writers, log;
   before(() => {
     writers = setupWriters();


### PR DESCRIPTION
- wraps the logger so that prefix is defaulted and added a getter/setter so that loglevel is still configurable.
- uses custom sinon matchers in tests.
- clearer describe labels.

ping @jlipps for review.